### PR TITLE
Update blog-music-identification.qmd

### DIFF
--- a/Applications/Blogs/blog-music-identification.qmd
+++ b/Applications/Blogs/blog-music-identification.qmd
@@ -17,6 +17,7 @@ categories:
   - CNN
   - Humanities
   - Audio
+  - Audio data
   - Music
   - CSI
   - Time-series
@@ -123,6 +124,8 @@ Google CoLab was uniquely helpful to me very early on when I first attempted to 
 - If you're looking for a high-level summary of the steps involved in preparing, training, evaluating, and productionizing any deep learning solution, consider the "Usage" section of the project Readme at [github.com/alanngnet/CoverHunterMPS/blob/main/README.md](https://github.com/alanngnet/CoverHunterMPS/blob/main/README.md)
 
 - Steal, borrow, and tweak the source code for your own purposes. There are a lot of generally useful bits in this project for any deep-learning classification solution. But even better would be to contribute improvements to this project to share your innovations more broadly. 
+
+- Use the Irish-specific CSI benchmarking datasets downloadable from https://www.irishtune.info/public/MLdata.htm to test how well your own CSI model can handle Irish traditional music.
 
 - Feel free to contact me ([alan@alan-ng.net](mailto:alan@alan-ng.net)) to tell this story if it can help expand the use of data science in the humanities.
 


### PR DESCRIPTION
Added note about downloadable benchmarking testset data at the end, and corresponding audio-data category tag.