### PR TITLE
Rewrite contribution guide: shorter, clearer, values-first

### DIFF
--- a/Learn/Guides/How-to-contribute.qmd
+++ b/Learn/Guides/How-to-contribute.qmd
@@ -13,237 +13,143 @@ categories:
 
 ---
 
-We want Nexus to serve also as a place where members of the community can share their knowledge. This guide answers the question, how to contribute to Nexus?
+Nexus is built by people sharing what they've learned with each other. This guide covers what we're looking for, what makes a good contribution, and how to submit one.
 
-## What kinds of resources are hosted on Nexus?
+## Our philosophy: share what you know {#philosophy}
+
+Nexus isn't a link aggregator — it's a place where community members share resources they have **personally used and can speak to**. Every contribution should reflect real experience:
+
+- **Share what has genuinely helped you.** A workshop that clarified a tricky concept, a library that saved you hours, a dataset that was well-suited for a particular task — if it made a difference in your work, it belongs here.
+- **Add your perspective.** Don't just point to a resource — tell the community *why* it's worth their time. What did you find most useful? What are its strengths and limitations? Who is it best suited for?
+- **Be authentic.** In an era of abundant AI-generated content, what makes Nexus valuable is the human curation and firsthand experience behind every post. We'd rather have a short, honest write-up from someone who used the resource than a polished summary from someone who didn't.
+
+## What kinds of resources can I share?
 {{< include ../../includes/common-resources-text.qmd >}}
 
-## Need inspiration for a good topic to post about?
-An ever-expanding list of requested resources can be found on the [Issues page (on GitHub)](https://github.com/UW-Madison-DataScience/ML-X-Nexus/labels/resource). Search for open issues that have the "Resource" label to check out some of our top priorities. If you'd like to tackle a given issue, please comment on the issue to let others know. 
+## What makes a good post? {#good-post}
 
-## What makes a good post?
-Creating a useful and engaging post for the ML+X Nexus involves a few key elements to ensure it is beneficial for the community. Here are some general guidelines to follow:
+You don't need to write a lot — you just need to be helpful and specific:
 
-### Clear and concise title
-The title should accurately reflect the content and main focus of the post. It should be engaging and specific, allowing readers to quickly understand what they can expect.
+1. **A clear title** that tells readers what the resource is and what it covers.
+2. **A brief description** in your own words: what the resource does, why you found it valuable, and who it's best for.
+3. **Prerequisites** — what should someone already know before diving in?
+4. **Strengths and limitations** — a balanced, honest take helps people decide if the resource fits their needs.
+5. **Links to related resources** on Nexus, when relevant.
 
-### Detailed description
-Provide a comprehensive overview of the resource or topic. This should include:
-
-- **Purpose and scope**: Clearly state what the resource covers and its main objectives. Explain why the content is valuable and how it can help practitioners.
-
-- **Key features**: Highlight the unique aspects or strengths of the resource. This could include practical examples, interactive elements, or real-world applications.
-
-- **Strengths and weaknesses**: Provide a balanced view by discussing both the strengths and any potential limitations of the resource. This helps users make informed decisions about whether the resource is right for them.
-
-### Prerequisites
-List any necessary background knowledge or skills required to fully benefit from the resource. This helps set expectations and ensures that users are adequately prepared. Include links to additional resources or tutorials that can help users gain the required knowledge.
-
-### Estimated time to complete
-Offer an estimate of the time commitment needed to complete the resource. This helps users plan their learning activities and manage their time effectively.
-
-### Accessibility and usability
-Ensure the resource is easy to access and use. We want the majority of resources on Nexus to be free and open source (with possibly a few rare exceptions for tools/resources in high-demand). Provide clear instructions on how to navigate and utilize the content. If the resource is hosted externally, include a direct link and any necessary login or access information.
-
-### Additional related resources
-Include links to related materials or further readings that can enhance the user’s understanding and provide more in-depth knowledge on the topic. This can include books, articles, other workshops, or case studies. When possible, link to any relevant materials which are already hosted on the Nexus platform.
+Use one of the [resource templates](#templates) below to get started — they'll guide you through the structure.
 
 ### Examples of good posts
-Please see below for a list of resources that meet our platform's standards. You can use these examples in conjunction with the template files provided in the next section to create your post. You can click "Improve this page" near the top right of each resource page to view the corresponding quarto file (.qmd) and code, or find the file in the [GitHub repo](https://github.com/UW-Madison-DataScience/ML-X-Nexus).
 
-#### External content
+Click "Improve this page" near the top right of any post to view its source code.
+
+**External content** (resources you're recommending):
+
 - [Learn: Workshop](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Workshops/Intro-Deeplearning_Keras.html)
 - [Learn: Book](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Books/Intro-Deeplearning_SimonJDPrince.html)
 - [Learn: Video](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Videos/Grokking.html)
-- [Application: Video](https://uw-madison-datascience.github.io/ML-X-Nexus/Applications/Videos/Other/CrossLabsAI-CrossRoads45-METL-Biophysics-based-Protein-Language-Model.html)
 - [Toolbox: Data](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Data/Gutenberg.html)
 
-#### Original content
+**Original content** (things you've written):
+
 - [Learn: Guide](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Guides/Github-desktop.html)
 - [Learn: Notebook](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/2025-05-07_RAG-Romeo-Juliet.html)
 - [Application: Blog](https://uw-madison-datascience.github.io/ML-X-Nexus/Applications/Blogs/blog-music-identification.html)
 
-## How to make a new post with GitHub?
-### Prerequisites
-You do not necessarily need specific training in anything, but you will need to use git and GitHub:
+## Need topic ideas?
 
-- Some familiarity with git or GitHub Desktop (`clone`, `pull`, `commit`, `push`)
-- A GitHub account and some familiarity with GitHub (Fork, Issues, Pull Request)
+Browse open issues labeled "Resource" on the [GitHub Issues page](https://github.com/UW-Madison-DataScience/ML-X-Nexus/labels/resource) for community-requested topics. If you'd like to tackle one, comment on the issue to let others know.
 
-### GitHub collaboration model
-We follow GitHub's collaboration model, so the general idea to make a post or edit a document is the same. The high-level steps include :
+## How to submit a new post {#submit}
 
-1. Get started with git and GitHub
-2. Create an issue announcing your plan to add a resource — see [ML+X Nexus Issues](https://github.com/UW-Madison-DataScience/ML-X-Nexus/issues)
-3. Fork the [ML+X-Nexus repository](https://github.com/UW-Madison-DataScience/ML-X-Nexus)
-4. Clone the forked repository onto your local machine
-5. Create a new branch
-6. Write the post
-    - (optional) Preview and iterate
-7. commit and push the changes
-8. Make a pull request
-9. Wait for review
+### Quick overview
 
-If you don't know how to use Git / GitHub already, it can be a little intimidating at first. A friendlier alternative could be to [download GitHub desktop](https://desktop.github.com/) and add your post using the instructions provided below. If you'd like to learn more about GitHub Desktop, check out the [Version Control with GitHub Desktop](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Guides/Github-desktop.html) guide on Nexus. If you need additional help (and work in a research lab at UW-Madison), you may also seek help at the Data Science Hub's [office hours ("Coding Meetup")](https://datascience.wisc.edu/hub/#dropin).
+1. Create a GitHub Issue announcing your planned resource
+2. Fork and clone the repo
+3. Create a branch, write your post using a template
+4. Commit, push, and open a Pull Request
+5. Wait for review
 
-#### 1. Get Started with GitHub Desktop (recommended if you're new to Git and GitHub)
+New to Git? We recommend [GitHub Desktop](https://desktop.github.com/) — see our [GitHub Desktop guide](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Guides/Github-desktop.html) for a walkthrough. UW-Madison researchers can also get help at the Data Science Hub's [Coding Meetup office hours](https://datascience.wisc.edu/hub/#dropin).
 
-1. Go to the [GitHub Desktop website](https://github.com/apps/desktop) and download the application for your operating system. Install GitHub Desktop by following the on-screen instructions.
-2. Open GitHub Desktop and sign in with your GitHub account. If you don't have one, you will need to [create your GitHub account](https://github.com/join) first.
+### Step-by-step instructions
 
-#### 2. Create an Issue on Nexus GitHub
-Before you start writing your content, create an issue on the Nexus GitHub to announce your intended addition. This helps the Nexus development team keep track of new contributions and provides an opportunity for feedback.
+#### 1. Create an Issue on GitHub
+Before writing, announce your plan so the team can provide early feedback.
 
-1. Go to the  [Nexus GitHub Issues](https://github.com/UW-Madison-DataScience/ML-X-Nexus/issues) page
-2. Click on the `New Issue` button.
-3. Title the issue with the name of your resource, and add a “Resource” label/tag (found on right side panel of issue post).
-4. Describe why you think this resource should be included on the Nexus platform.
-5. Wait for feedback: Wait for one of the Nexus developers to provide feedback or comments on your issue before proceeding.
+1. Go to [Nexus GitHub Issues](https://github.com/UW-Madison-DataScience/ML-X-Nexus/issues) and click **New Issue**.
+2. Title it with the name of your resource and add the "Resource" label.
+3. Briefly describe why this resource should be on Nexus.
+4. Wait for feedback before proceeding.
 
-#### 3. Fork the Repository
-The purpose of a Fork is to create a copy of the original repository that can be syncronized. In an open-source collaboration,
-the original repository will not allow you to make edits directly. Instead, you will update your Fork and then ask the
-original repository owners to integrate your changes through a Pull Request (PR), which you will do in step 8.
+#### 2. Fork and clone the repo
 
-1. Go to the [ML+X-Nexus repository](https://github.com/UW-Madison-DataScience/ML-X-Nexus) on GitHub.
-2.  Click the `Fork` button at the top-right corner of the page.
-    - This will create a copy of the repository under your GitHub account.
-    - You will now be able to make changes to your Forked copy of the repository.
+1. Go to the [ML+X Nexus repository](https://github.com/UW-Madison-DataScience/ML-X-Nexus) and click **Fork** (top-right).
+2. Clone your fork to your local machine. In GitHub Desktop: **File > Clone Repository**, paste the URL, and click **Clone**.
 
-#### 4. Clone the Repository to Your System to Your Local System
-Cloning your Fork to your local filesystem will allow you to use your development environment of choice to make changes.
+#### 3. Create a branch and write your post
 
-1. From your new forked version of the repo on GitHub, click the green `Code` button to copy the HTTPS URL of the fork
-2. In GitHub Desktop, click on `File` > `Clone Repository`.
-3. Paste the URL and click `Clone`
+1. In GitHub Desktop: **Branch > New Branch**. Name it descriptively (e.g., `workshop-introDL`, `video-NeurIPS2024`).
+2. Copy the appropriate [template](#templates) into the correct folder (see [folder structure](#folder-structure) below).
+3. Edit the template in your preferred text editor. The template comments will guide you.
 
-#### 5. Create a New Branch
-It is common practice to create a new branch anytime you perform work as a new feature, update, or fix. This is often
-called a "feature branch". The name comes from the idea that each feature should have its own branch, in an effort to
-keep things tidy.
+#### 4. Commit, push, and open a Pull Request
 
-1. In GitHub Desktop, click on Branch > New Branch.
-2. Name your new branch descriptively based on the resource type and name (e.g., workshop-introDL, video-NeurIPS2024, etc.).
+1. In GitHub Desktop, write a descriptive commit message and click **Commit**.
+2. Click **Push** to upload your changes.
+3. On GitHub, click **Compare & pull request**, ensure you're merging into the `main` branch, write a short description, and submit.
 
-#### 6. Write Your Post
-This is where you make changes to add your new content. Often times this starts by copying a template of your desired
-content (links below) into the desired folder and editing it to reflect the content you want to share.
+#### 5. Review
+A Nexus developer will review your PR. They may request changes — just push additional commits to your branch.
 
-1. Open your favorite text editor or IDE (e.g., Visual Studio Code, Sublime Text).
-2. Write your post in the appropriate format. Follow the guidelines below, making use the template files provided.
+### Resource templates {#templates}
 
-#### Resource templates
-If applicable, start with one of the relevant template files linked below. There are comments in each template that will help you make the appropriate edits for your resource. You can also check out how other posts have been formatted by clicking "Improve this page" from a given post's webpage. This will bring you directly to the qmd file for that post.
+Start with one of these and follow the inline comments:
 
-- [Educational - blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-book.qmd)
-- [Educational - book](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-bookp.qmd)
-- [Educational - video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-video.qmd): lectures, forums, seminars, etc.
-- [Educational - workshop](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-workshop.qmd)
+**Learn:**
+[Blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-blog.qmd) · [Book](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-book.qmd) · [Video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-video.qmd) · [Workshop](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-workshop.qmd)
 
+**Applications:**
+[Blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_application-blog.qmd) · [Video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_application-video.qmd)
 
-- [Application - blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_application-blog.qmd)
-- [Application - video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_application-video.qmd)
+**Toolbox:**
+[Data](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_toolbox-data.qmd) · [Model](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_toolbox-model.qmd) · [Library](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_toolbox-library.qmd)
 
-- [Toolbox - data](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_toolbox-data.qmd)
-- [Toolbox - model](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_toolbox-model.qmd)
-- [Toolbox - library](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_toolbox-library.qmd)
+### Where to place your file {#folder-structure}
 
-#### Where to place your resource qmd file
-We want the site to be constantly evolving with the community, and our intention is to keep the contributions to the site as free as possible. However, we added some sections to structure the site a little bit:
+Place your `.qmd` file in the appropriate subfolder:
 
 ```txt
-
-├── Applications
-│   ├── Blogs
-│   ├── Videos
-│   ├── Papers
-│   ├── Playlists
-├── Learn
-│   ├── Blogs
-│   ├── Books
-│   ├── Guides
-│   ├── Notebooks
-│   ├── Videos
-│   ├── Workshops
-├── Toolbox
-│   ├── Compute
-│   ├── Data 
-│   ├── GenAI 
-│   ├── Libraries 
-│   ├── Models 
+├── Learn/
+│   ├── Blogs, Books, Guides, Notebooks, Videos, Workshops
+├── Applications/
+│   ├── Blogs, Videos
+├── Toolbox/
+│   ├── Compute, Data, GenAI, Libraries, MLOps, Models
 ```
-**Note**: Some subfolders may not exist yet (e.g., Code, Data) since no one has contributed a resource from one of those categories yet, and git doesn't allow empty folders. If your resource doesn't belong to one of the categories listed above, you may add a new one. We'll discuss this new category when we review your initial "Issue" announcing the resource addition.
 
+If your resource doesn't fit an existing category, propose a new one in your GitHub Issue.
 
-##### How to preview new content
-It is possible to preview the page you are creating on your local machine before you make the pull request, or even
-commit any changes. This requires Quarto to be installed on your local machine. Note that this can be very helpful, but
-try not to spend too much time iterating without committing, pushing, and completing the Pull Request process. You can
-always come back to this step and improve the content after it is submitted for review.
+### Previewing locally (optional)
 
-1. [Install Quarto](https://quarto.org/docs/get-started/) on your local machine
-2. Open terminal/shell/command line and run the `quarto preview <my_new_content.qmd>` command (replace <my_new_content.qmd> with your content file)
-3. Wait for the files to render (this can take a while the first time as it renders all pages the first time)
-4. A browser window should open with your version of the ML+X Nexus page
-5. Review your changes
+If you have [Quarto](https://quarto.org/docs/get-started/) installed, you can preview your post before submitting:
 
-While the `quarto preview` command is running, the content will update when it notices a change. This allows you to
-iterate quickly between review and editing. When you want to stop previewing, cancel the `quarto preview` command.
-Usually this is done by pressing `Ctrl`+`C` in the terminal window.
+```bash
+quarto preview <your_file.qmd>
+```
 
-#### 7. Commit and Push Changes
-Commit and push changes to your feature branch as you work. You can commit and push as many times as you want to track the updates
-anc changes you've made.
+Don't spend too much time perfecting things locally — you can always iterate after the PR is open.
 
-1. In GitHub Desktop, you should see your changes listed under Changes.
-2. Write a descriptive commit message (e.g., Add new resource: workshop-introDL).
-3. Click `Commit to your-branch-name`.
-4. Click on `Repository` > `Push` to push your changes to GitHub.
+## How to improve an existing post
 
-#### 8. Make a Pull Request
-Pull Request (PR) is the term used when you _request_ that one branch be _pulled_ into another. The process of combining
-branches is often called a merge. In this case, you will ask the original repository to merge your Fork's feature branch
-into their main branch. This PR will notify the original repository owner of your request and will then be reviewed.
+Want to fix a typo, add a code-along, or share your perspective on an existing resource? Anyone is welcome to suggest improvements.
 
-1. Go to your forked repository on GitHub.
-2. Click on the Compare & pull request button.
-3. Ensure you are merging into the "main" branch of the ML+X-Nexus repository.
-4. Write a descriptive title and comment for your pull request.
-5. Click `Create pull request`.
+1. From the post's page on Nexus, click **"Improve this page"** (top-right).
+2. On GitHub, click the pencil icon to edit the file in your browser.
+3. Make your changes, scroll down, and choose **"Create a new branch for this commit and start a pull request."**
+4. Click **Propose changes**, then **Create pull request**.
 
-#### 9. Wait for Review
-Your Pull Request (PR) will need to be reviewed by the owner of the original repository.
-
-1. One of the Nexus developers will review your pull request. They may provide feedback or request changes.
-2. Address any feedback and push additional commits as needed.
-
-## How to improve an existing post?
-Want to add a code-along exercise to an existing post, add your perspective, or correct a typo? Anyone is welcome and encouraged to suggest improvements to existing materials hosted on Nexus! The most straightforward way to do this is to click "Improve this page" from the post's webpage on Nexus to suggest your edits. The below steps will walk you through this process. 
-
-#### Steps to improve a post on Nexus via GitHub (no software installation needed):
-
-1. **Click "Improve this page":** This will redirect you to the GitHub repository where the content of the post is stored.
-
-2. **Edit the file directly on GitHub:**
-   - On the GitHub page, click the pencil icon (✏️) at the top right of the file to edit the content directly in your browser. No need to install any git software!
-   - Make your changes in the text editor. You can add a code-long exercise, share your perspective, or correct any typos.
-
-3. **Commit your changes:**
-   - After you have made your edits, scroll down to the "Commit changes" section.
-   - Write a brief description of what you changed.
-   - Choose the option to "Create a new branch for this commit and start a pull request."
-
-4. **Create a pull request:**
-   - Click the "Propose changes" button.
-   - You will be taken to a new page where you can review your changes. 
-   - Click "Create pull request" to submit your changes for review.
-
-Congratulations! You have suggested an improvement to a Nexus post. The repository maintainers will review your pull request, and if everything looks good, your changes will be merged into the post.
-
-**Note:** While you can make these edits directly on GitHub without any software installation, we recommend all ML practitioners learn git! [Check out our git category search resources](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/#category=Git/GitHub).
+That's it — the maintainers will review and merge if everything looks good.
 
 ## Questions?
-If you any lingering questions on how to contribute, please feel free to post to the [Nexus Q&A](https://github.com/UW-Madison-DataScience/ML-X-Nexus/discussions/categories/q-a) on GitHub. We will improve this guide based on additional questions/comments we receive.
 
-
-
+Post to the [Nexus Q&A on GitHub](https://github.com/UW-Madison-DataScience/ML-X-Nexus/discussions/categories/q-a). We'll improve this guide based on the feedback we receive.


### PR DESCRIPTION
Restructure the How-to-contribute guide to address two main issues:

- The guide was long and hard to follow. Reduced from ~250 lines to ~130 by tightening prose, removing redundancy in the step-by-step GitHub instructions, and using more scannable formatting (anchor links, compact template lists, condensed folder structure).

- Added a new "Our philosophy" section at the top that clearly articulates the core value proposition: share resources you've personally used and can speak to, add your own perspective, and prioritize authentic human curation over generic AI-generated content.

Also fixed two broken template links in the original (blog template linked to the book file, book link pointed to nonexistent template_learn-bookp.qmd).

https://claude.ai/code/session_018h9ANYS89Q6JGoP45VtkX2