### PR TITLE
Add notebook contribution workflow and template

### DIFF
--- a/Contributor-templates/template_learn-notebook.qmd
+++ b/Contributor-templates/template_learn-notebook.qmd
@@ -1,0 +1,66 @@
+---
+title: "Title of Your Notebook" # enter a descriptive title for your notebook
+author:
+  - name: First Last # replace with your name
+    email: myemail@wisc.edu # If you prefer not to share your email, delete this entire line (including "email:").
+
+date: YYYY-MM-DD # enter today's date as YYYY-MM-DD
+date-format: long # leave as is
+image: "../../../images/vincent-van-zalinge-mDohQISBnCk-unsplash.jpg" # Add a representative image to the images folder and update this filename.
+
+# Enter relevant categories/tags. Check existing tags at https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/
+# Always include "Notebooks" and "Code-along". Add topic-specific tags as needed.
+categories:
+  - Notebooks # always include
+  - Code-along # always include
+  - Deep learning # descriptor(s) for the method(s) of focus
+
+jupyter: python3 # leave as is — tells Quarto this is a Python notebook
+execute:
+  echo: true # show code cells in the rendered page
+  eval: false # prevents execution during Quarto build (leave as false)
+
+---
+<!-- MARKDOWN COMMENT:
+NOTEBOOK CONTRIBUTION WORKFLOW:
+1. Develop your content in a Jupyter notebook (.ipynb) as usual
+2. Convert to .qmd:  quarto convert your_notebook.ipynb
+3. Add the YAML front matter above to the generated .qmd file
+4. Submit your PR with the .qmd file placed in Learn/Notebooks/
+5. After merge, a GitHub Action will auto-generate the .ipynb from your .qmd
+
+For a good example, see:
+  Page: https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/2025-05-07_RAG-Romeo-Juliet.html
+  Source: https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Learn/Notebooks/2025-05-07_RAG-Romeo-Juliet.qmd
+
+OPTIONAL: Add a Colab badge so readers can run the notebook directly (update the URL with your filename):
+-->
+[![](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/UW-Madison-DataScience/ML-X-Nexus/blob/main/Learn/Notebooks/YOUR_NOTEBOOK_FILENAME.ipynb)
+
+<!-- MARKDOWN COMMENT: Replace the text below with your notebook introduction -->
+Brief description of what this notebook demonstrates and why it's useful. What will the reader learn? What problem does it solve?
+
+#### Prerequisites
+- [Prerequisite Resource 1](URL)
+- [Prerequisite Resource 2](URL)
+
+## Your content here
+<!-- MARKDOWN COMMENT:
+Your notebook content goes here. Use ```{python} code fences for code cells.
+Example:
+
+```{python}
+import pandas as pd
+df = pd.read_csv("data.csv")
+df.head()
+```
+
+Intersperse code with markdown explanations so readers can follow along.
+-->
+
+## Questions?
+If you any lingering questions about this resource, please feel free to post to the [Nexus Q&A](https://github.com/UW-Madison-DataScience/ML-X-Nexus/discussions/categories/q-a) on GitHub. We will improve materials on this website as additional questions come in.
+
+## See also
+- [Related Resource 1](Link to related resource 1): Brief description of related resource 1.
+- [Related Resource 2](Link to related resource 2): Brief description of related resource 2.

--- a/Learn/Guides/How-to-contribute.qmd
+++ b/Learn/Guides/How-to-contribute.qmd
@@ -106,7 +106,7 @@ A Nexus developer will review your PR. They may request changes — just push ad
 Start with one of these and follow the inline comments:
 
 **Learn:**
-[Blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-blog.qmd) · [Book](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-book.qmd) · [Video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-video.qmd) · [Workshop](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-workshop.qmd)
+[Blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-blog.qmd) · [Book](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-book.qmd) · [Notebook](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-notebook.qmd) · [Video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-video.qmd) · [Workshop](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-workshop.qmd)
 
 **Applications:**
 [Blog](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_application-blog.qmd) · [Video](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_application-video.qmd)
@@ -138,6 +138,23 @@ quarto preview <your_file.qmd>
 ```
 
 Don't spend too much time perfecting things locally — you can always iterate after the PR is open.
+
+### Contributing a Jupyter notebook {#notebooks}
+
+If you're sharing a code-along notebook (e.g., a tutorial, demo, or walkthrough), the workflow is slightly different from other resource types. Nexus stores notebooks as `.qmd` (Quarto markdown) files, and a GitHub Action automatically generates the `.ipynb` after your PR is merged.
+
+**The workflow:**
+
+1. **Develop in a notebook** — write your content in Jupyter (`.ipynb`) as you normally would.
+2. **Convert to `.qmd`** — when you're ready to submit, run:
+    ```bash
+    quarto convert your_notebook.ipynb
+    ```
+    This produces a `.qmd` file with your code cells and markdown preserved.
+3. **Add YAML front matter** — open the `.qmd` and add the required metadata header at the top. Use the [notebook template](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Contributor-templates/template_learn-notebook.qmd) as a reference. Key fields include `jupyter: python3` and `execute: eval: false` (prevents code from running during the site build).
+4. **Submit a PR with the `.qmd` file** — place it in `Learn/Notebooks/`. Do **not** include the `.ipynb` in your PR; the GitHub Action will generate it automatically after merge.
+
+For a working example, see the [RAG: Romeo and Juliet notebook](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/2025-05-07_RAG-Romeo-Juliet.html) and its [source `.qmd`](https://github.com/UW-Madison-DataScience/ML-X-Nexus/blob/main/Learn/Notebooks/2025-05-07_RAG-Romeo-Juliet.qmd).
 
 ## How to improve an existing post
 


### PR DESCRIPTION
- Add a "Contributing a Jupyter notebook" section to the guide that explains the develop-in-ipynb → convert-to-qmd → submit-PR workflow, including the fact that a GitHub Action auto-generates the .ipynb after merge.
- Create a new notebook template (template_learn-notebook.qmd) with the required YAML front matter (jupyter, execute settings) and inline comments walking contributors through the process.
- Link the new template from the resource templates list in the guide.

https://claude.ai/code/session_018h9ANYS89Q6JGoP45VtkX2