### PR TITLE
Move MLflow 101 from Learn/Blogs to Toolbox/MLOps

### DIFF
--- a/Toolbox/MLOps/index.qmd
+++ b/Toolbox/MLOps/index.qmd
@@ -12,7 +12,7 @@ listing:
   contents:
     - "./*.qmd"
     - "!./index.qmd"
-    - "../../Learn/Blogs/mlflow-101.qmd"
+
 
 toc: false
 toc-location: body

--- a/Toolbox/MLOps/mlflow-101.qmd
+++ b/Toolbox/MLOps/mlflow-101.qmd
@@ -7,10 +7,9 @@ author:
 date: 2025-08-14  
 date-format: long  
 
-image: "../../../images/mlflow-logo.png"
+image: "../../images/mlflow-logo.png"
 
 categories:
-  - Blogs
   - Libraries
   - Reproducibility
   - Sklearn


### PR DESCRIPTION
The MLflow 101 article is a practical tutorial about an MLOps tool, not a blog post. Move it to Toolbox/MLOps where it belongs, update the image path, remove the "Blogs" category, and drop the now-unnecessary cross-reference from the MLOps index.

https://claude.ai/code/session_01N99vVDACQCSzC2XtuQceYM