### PR TITLE
Bold level 1 sidebar items and can now collapse

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -34,7 +34,7 @@ website:
       - href: Learn/Guides/How-to-contribute.qmd
         text: "How to contribute?" 
 
-      - text: "Learn"
+      - section: "Learn"
         href: Learn/index.qmd 
         contents:
           - text: "Blogs"
@@ -50,18 +50,18 @@ website:
           - text: "Workshops"
             href: Learn/Workshops/index.qmd
 
-      - text: "Projects"
+      - section: "Projects"
         href: Projects/index.qmd
         contents:
           - text: "ML Marathon"
             href: Projects/ML-Marathon/index.qmd
 
-      - text: "Stories"
+      - section: "Stories"
         href: Applications/index.qmd
         contents:
           - text: "Blogs"
             href: Applications/Blogs/index.qmd
-          - text: "Videos"
+          - section: "Videos"
             href: Applications/Videos/index.qmd
             contents:
             - text: "AI @ UW"
@@ -75,7 +75,7 @@ website:
             - text: "Other"
               href: Applications/Videos/Other/index.qmd
 
-      - text: "Toolbox"
+      - section: "Toolbox"
         href: Toolbox/index.qmd
         contents:
           - text: "Benchmarks"

--- a/fonts.scss
+++ b/fonts.scss
@@ -16,3 +16,8 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif;
 h1, h2, h3, h4, h5, h6 {
     font-family: "Montserrat", sans-serif;
 }
+
+/* Bold top-level section titles in the sidebar */
+.sidebar-menu-container > ul > li > div > .sidebar-item-text {
+  font-weight: bold !important;
+}


### PR DESCRIPTION
Potentially closes #61 ? 

- Updated fonts.scss to include bold first level sidebar items.
- Updated _quarto.yml sidebar text to be "section" instead of "text" so that it can be minimized or collapsed. Additionally, they can all start collapsed if you update the collapse-level to be 1 in the _quarto.yml file. Since there is a level 3 in Stories>Videos>, it might even be worth thinking about changing it from 2 to 3?