### PR TITLE
Cross-list tutorial Toolbox tiles under Learn

### DIFF
--- a/Learn/Guides/index.qmd
+++ b/Learn/Guides/index.qmd
@@ -12,6 +12,16 @@ listing:
   contents:
     - "./*.qmd"
     - "!./index.qmd"
+    # cross-listed Toolbox tiles tagged "Guides"
+    - "../../Toolbox/Compute/NRP-Nautilus.qmd"
+    - "../../Toolbox/Compute/GoogleColab.qmd"
+    - "../../Toolbox/Compute/CHTC.qmd"
+    - "../../Toolbox/Compute/BadgerCompute.qmd"
+    - "../../Toolbox/Compute/UW-Cloud-Services.qmd"
+    - "../../Toolbox/MLOps/mlflow-101.qmd"
+    - "../../Toolbox/GenAI/NotebookLM.qmd"
+    - "../../Toolbox/GenAI/OpenScholar.qmd"
+    - "../../Toolbox/GenAI/GenAI-at-UW-Madison.qmd"
 
 toc: false
 toc-location: body

--- a/Learn/index.qmd
+++ b/Learn/index.qmd
@@ -21,6 +21,16 @@ listing:
     - "!./**/index.qmd"
     - "!./**/*.ipynb"
     - "../Applications/Videos/Forums/mlx_2025-02-10.qmd"
+    # cross-listed Toolbox tiles with substantial tutorial / how-to content
+    - "../Toolbox/Compute/NRP-Nautilus.qmd"
+    - "../Toolbox/Compute/GoogleColab.qmd"
+    - "../Toolbox/Compute/CHTC.qmd"
+    - "../Toolbox/Compute/BadgerCompute.qmd"
+    - "../Toolbox/Compute/UW-Cloud-Services.qmd"
+    - "../Toolbox/MLOps/mlflow-101.qmd"
+    - "../Toolbox/GenAI/NotebookLM.qmd"
+    - "../Toolbox/GenAI/OpenScholar.qmd"
+    - "../Toolbox/GenAI/GenAI-at-UW-Madison.qmd"
 
 
 toc: false

--- a/Toolbox/Compute/BadgerCompute.qmd
+++ b/Toolbox/Compute/BadgerCompute.qmd
@@ -8,6 +8,7 @@ date-format: long
 image: "../../../images/BadgerCompute.png"
 categories:
   - Compute
+  - Guides
   - UW-Madison
   - GPU
   - Jupyter

--- a/Toolbox/Compute/CHTC.qmd
+++ b/Toolbox/Compute/CHTC.qmd
@@ -9,6 +9,7 @@ date-format: long
 image: "../../../images/CHTC.png"
 categories:
   - Compute
+  - Guides
   - UW-Madison
   - GPU
   - HPC

--- a/Toolbox/Compute/GoogleColab.qmd
+++ b/Toolbox/Compute/GoogleColab.qmd
@@ -8,6 +8,7 @@ date-format: long
 image: "../../../images/GoogleColab.png"
 categories:
   - Compute
+  - Guides
   - Jupyter
   - Google
   - GPU

--- a/Toolbox/Compute/NRP-Nautilus.qmd
+++ b/Toolbox/Compute/NRP-Nautilus.qmd
@@ -9,6 +9,7 @@ image: "../../../images/NRP-logo-square.jpg"
 description: "Free open-weight LLM endpoints plus free Kubernetes GPU compute for InCommon-affiliated researchers. Reference + Python code-along for hitting the NRP-hosted LLM API."
 categories:
   - Compute
+  - Guides
   - Notebooks
   - Code-along
   - GPU

--- a/Toolbox/Compute/UW-Cloud-Services.qmd
+++ b/Toolbox/Compute/UW-Cloud-Services.qmd
@@ -10,6 +10,7 @@ date-format: long
 image: "../../../images/uw-logo-vertical-color-web-digital.png"
 categories:
   - Compute
+  - Guides
   - Cloud
   - UW-Madison
   - AWS

--- a/Toolbox/GenAI/GenAI-at-UW-Madison.qmd
+++ b/Toolbox/GenAI/GenAI-at-UW-Madison.qmd
@@ -8,8 +8,9 @@ date: 2025-01-07
 date-modified: 2026-03-10
 date-format: long
 image: "../../../images/UW-genAI-services.png" 
-categories: 
+categories:
   - GenAI
+  - Guides
   - Microsoft Copilot
   - Gemini
   - UW-Madison

--- a/Toolbox/GenAI/NotebookLM.qmd
+++ b/Toolbox/GenAI/NotebookLM.qmd
@@ -7,8 +7,9 @@ author:
 date: 2024-12-09
 date-format: long
 image: "../../../images/NotebookLM.jpg" # Replace with a representative image for NotebookLM
-categories: 
+categories:
   - GenAI
+  - Guides
   - NLP
   - Summarization
   - Gemini

--- a/Toolbox/GenAI/OpenScholar.qmd
+++ b/Toolbox/GenAI/OpenScholar.qmd
@@ -10,6 +10,7 @@ image: "../../../images/OpenScholar.png"
 
 categories:
   - GenAI
+  - Guides
   - NLP
   - LLM
   - RAG

--- a/Toolbox/MLOps/mlflow-101.qmd
+++ b/Toolbox/MLOps/mlflow-101.qmd
@@ -11,6 +11,7 @@ image: "../../images/mlflow-logo.png"
 
 categories:
   - Libraries
+  - Guides
   - Reproducibility
   - Sklearn
   - MLOps


### PR DESCRIPTION
Several Toolbox tiles (NRP, Colab, CHTC, BadgerCompute, UW Cloud Services, mlflow-101, NotebookLM, OpenScholar, GenAI at UW) are essentially how-to guides — you go to those pages to learn the tool. They were invisible on the Learn landing page because the listing only globbed Learn/**.

Tag each with the Guides category and explicitly add them to the contents lists in Learn/index.qmd and Learn/Guides/index.qmd so they appear under both Learn (top-level) and Learn > Guides.