### PR TITLE
Add 1Password secrets management guide for Claude Code

### DIFF
--- a/Learn/Guides/claude-code-cloud-setup.qmd
+++ b/Learn/Guides/claude-code-cloud-setup.qmd
@@ -939,6 +939,22 @@ So the real secret only ever lives in the child process's memory. The `.env` on 
 There is a separate command, [`op inject`](https://developer.1password.com/docs/cli/reference/commands/inject/), that *does* write resolved values to a file — useful for tools that can't be wrapped in `op run` (e.g., a daemon's config file). But that output lands on disk, so you gitignore it and delete it afterward. **Default to `op run`** unless you have a specific reason to materialize the file.
 :::
 
+::: {.callout-tip}
+## Two ways to wire this up: `op run` vs. the 1Password SDKs
+This guide focuses on `op run` because it works with any language and requires zero code changes — you keep reading `os.environ["OPENAI_API_KEY"]` exactly as before.
+
+If you'd rather have your app fetch secrets directly (no shell wrapper), 1Password also ships [**native SDKs for Python, Node, Go, .NET, and others**](https://developer.1password.com/docs/sdks/) that resolve `op://` references from inside your code:
+
+```python
+# Python example — pulls the secret at startup, no .env file at all
+from onepassword import Client
+client = await Client.authenticate(auth=os.environ["OP_SERVICE_ACCOUNT_TOKEN"], ...)
+api_key = await client.secrets.resolve("op://Private/OpenAI/api-key")
+```
+
+The SDKs are the more natural fit for long-running web apps (Flask, FastAPI, Express, etc.) and for [Kubernetes-style deployments](https://blog.1password.com/expanding-programmatic-access/), where wrapping the process entrypoint with `op run` is awkward. They also support [**1Password Environments**](https://developer.1password.com/docs/environments/), a newer dedicated home for application secrets (as opposed to keeping them in your personal vault). See ["Replace .env with 1Password SDKs"](https://blog.1password.com/replace-env-files-1password-sdks/) for a getting-started walkthrough.
+:::
+
 #### Set it up
 
 **Step 1 — Install the 1Password CLI** ([official install docs](https://developer.1password.com/docs/cli/get-started/)):
@@ -982,9 +998,13 @@ HF_TOKEN=op://Private/HuggingFace/token
 
 #### Do I need to be logged into 1Password? How often does it expire?
 
-**For interactive use on your own machine: yes, the 1Password desktop app must be unlocked when you run `op run`.** Day-to-day, this is barely noticeable — the app auto-locks after a period of inactivity (default 10 minutes after sleep, configurable in **Settings → Security**), and unlocking it is a Touch ID / Windows Hello tap. If you run `op run` while the app is locked, it prompts you to unlock right then. No long-lived session tokens land on disk.
+**For interactive use on your own machine: yes, the 1Password desktop app must be unlocked when you run `op run`.** Day-to-day, this is barely noticeable — unlocking the app is a Touch ID / Windows Hello tap, and if you run `op run` while the app is locked, it prompts you to unlock right then. No long-lived session tokens land on disk.
 
-If you don't use the desktop-app integration and authenticate via `op signin` instead, **session tokens default to 30 minutes** of inactivity before they expire and you have to re-authenticate. See [Sign in and out](https://developer.1password.com/docs/cli/sign-in-manually/).
+A few specifics on expiration:
+
+- **Desktop-authenticated CLI/SDK sessions expire after 10 minutes of inactivity, or whenever 1Password locks** ([1Password announcement, Feb 2026](https://blog.1password.com/expanding-programmatic-access/)). That means if you run `op run` once and then idle for 15 minutes, the next `op run` will prompt for biometrics again. This is by design — short windows reduce the blast radius if your machine is left unlocked.
+- **The desktop app's own auto-lock** is separately configurable in **Settings → Security**.
+- **If you authenticate via `op signin` without desktop integration**, session tokens default to 30 minutes of inactivity before re-auth. See [Sign in and out](https://developer.1password.com/docs/cli/sign-in-manually/).
 
 **For a long-running server (e.g., a Gemini- or Claude-backed web app serving external users): you do *not* want to rely on a user being logged into 1Password on the server.** That would mean the server can't restart without a human at a keyboard — clearly a dealbreaker for anything production-shaped.
 

--- a/Learn/Guides/claude-code-cloud-setup.qmd
+++ b/Learn/Guides/claude-code-cloud-setup.qmd
@@ -940,19 +940,30 @@ There is a separate command, [`op inject`](https://developer.1password.com/docs/
 :::
 
 ::: {.callout-tip}
-## Two ways to wire this up: `op run` vs. the 1Password SDKs
-This guide focuses on `op run` because it works with any language and requires zero code changes — you keep reading `os.environ["OPENAI_API_KEY"]` exactly as before.
+## `op run` vs. the 1Password SDKs — which one do I use?
 
-If you'd rather have your app fetch secrets directly (no shell wrapper), 1Password also ships [**native SDKs for Python, Node, Go, .NET, and others**](https://developer.1password.com/docs/sdks/) that resolve `op://` references from inside your code:
+You have two ways to pull secrets from 1Password. They aren't competing; they fit different shapes of project.
 
-```python
-# Python example — pulls the secret at startup, no .env file at all
-from onepassword import Client
-client = await Client.authenticate(auth=os.environ["OP_SERVICE_ACCOUNT_TOKEN"], ...)
-api_key = await client.secrets.resolve("op://Private/OpenAI/api-key")
+**`op run` — wraps a command at the shell level.** Your code is unchanged — it reads `os.environ["OPENAI_API_KEY"]` like always.
+
+```bash
+op run --env-file=.env -- python train.py
+op run --env-file=.env -- claude
 ```
 
-The SDKs are the more natural fit for long-running web apps (Flask, FastAPI, Express, etc.) and for [Kubernetes-style deployments](https://blog.1password.com/expanding-programmatic-access/), where wrapping the process entrypoint with `op run` is awkward. They also support [**1Password Environments**](https://developer.1password.com/docs/environments/), a newer dedicated home for application secrets (as opposed to keeping them in your personal vault). See ["Replace .env with 1Password SDKs"](https://blog.1password.com/replace-env-files-1password-sdks/) for a getting-started walkthrough.
+Use it for: CLI scripts, training jobs, dev tooling, Makefile targets, Claude Code itself — anything you launch from a terminal. This is the default; start here.
+
+**The 1Password SDK — embed the fetch inside your app code.** Your app imports the [Python / Node / Go / .NET SDK](https://developer.1password.com/docs/sdks/) and calls `resolve()` at startup:
+
+```python
+from onepassword import Client
+client = await Client.authenticate(auth=os.environ["OP_SERVICE_ACCOUNT_TOKEN"], ...)
+GEMINI_API_KEY = await client.secrets.resolve("op://Research/Gemini/api-key")
+```
+
+Use it for: long-running web apps (Flask, FastAPI, Express), Kubernetes pods, daemons — anything where wrapping the entrypoint with `op run` is awkward, or where you want to re-fetch / rotate secrets without restarting the process.
+
+The SDKs also pair with [**1Password Environments**](https://developer.1password.com/docs/environments/) — a per-app bucket of secrets, separate from your Private vault — which is the recommended home for production app secrets. See ["Replace .env with 1Password SDKs"](https://blog.1password.com/replace-env-files-1password-sdks/) for a walkthrough.
 :::
 
 #### Set it up
@@ -996,19 +1007,24 @@ HF_TOKEN=op://Private/HuggingFace/token
 
 **Step 5 — Run commands through `op run`.** Your script reads `os.environ["OPENAI_API_KEY"]` (Python) or `process.env.OPENAI_API_KEY` (Node) exactly as before — `op run` populates them transparently.
 
-#### Do I need to be logged into 1Password? How often does it expire?
+#### Authentication and session lifetime
 
-**For interactive use on your own machine: yes, the 1Password desktop app must be unlocked when you run `op run`.** Day-to-day, this is barely noticeable — unlocking the app is a Touch ID / Windows Hello tap, and if you run `op run` while the app is locked, it prompts you to unlock right then. No long-lived session tokens land on disk.
+How `op` authenticates depends on whether a human is at the keyboard.
 
-A few specifics on expiration:
+**Interactive (your laptop, with desktop app integration):** The 1Password desktop app must be unlocked. Day-to-day this is barely noticeable — unlocking is a Touch ID / Windows Hello tap, and `op run` triggers an unlock prompt if the app is locked. Two timers to know:
 
-- **Desktop-authenticated CLI/SDK sessions expire after 10 minutes of inactivity, or whenever 1Password locks** ([1Password announcement, Feb 2026](https://blog.1password.com/expanding-programmatic-access/)). That means if you run `op run` once and then idle for 15 minutes, the next `op run` will prompt for biometrics again. This is by design — short windows reduce the blast radius if your machine is left unlocked.
+- **Desktop-authenticated CLI/SDK sessions expire after 10 minutes of inactivity, or whenever 1Password locks** ([1Password announcement, Feb 2026](https://blog.1password.com/expanding-programmatic-access/)). After that, your next `op run` re-prompts for biometrics. The short window is deliberate — it limits exposure if you walk away from an unlocked machine.
 - **The desktop app's own auto-lock** is separately configurable in **Settings → Security**.
-- **If you authenticate via `op signin` without desktop integration**, session tokens default to 30 minutes of inactivity before re-auth. See [Sign in and out](https://developer.1password.com/docs/cli/sign-in-manually/).
+- **If you `op signin` without desktop integration**, session tokens default to 30 minutes of inactivity. See [Sign in and out](https://developer.1password.com/docs/cli/sign-in-manually/).
 
-**For a long-running server (e.g., a Gemini- or Claude-backed web app serving external users): you do *not* want to rely on a user being logged into 1Password on the server.** That would mean the server can't restart without a human at a keyboard — clearly a dealbreaker for anything production-shaped.
+**Unattended (servers, CI runners, cron, scheduled jobs):** Use a [**service account**](https://developer.1password.com/docs/service-accounts/get-started/) — a non-human identity scoped to specific vaults. You create the account in the 1Password admin console, get a token like `ops_eyJhbG...`, and export it as `OP_SERVICE_ACCOUNT_TOKEN`. Both `op run` and the SDKs work non-interactively from that point on:
 
-The supported pattern for servers is a [**service account**](https://developer.1password.com/docs/service-accounts/get-started/) (covered below) — a non-human identity with its own long-lived token that the server uses to fetch secrets at startup. No desktop app, no biometrics, no user login required on the server.
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+op run --env-file=.env -- python app.py
+```
+
+Service-account tokens don't expire on their own — they're valid until you rotate or revoke them. Treat the token like any other production credential: don't commit it, and load it through whatever mechanism your platform already uses for sensitive env vars (CI secret stores, your hosting platform's secret UI, systemd `EnvironmentFile`, etc.). See the [CI/CD integrations docs](https://developer.1password.com/docs/ci-cd/) for GitHub Actions, GitLab, Kubernetes, and other recipes.
 
 #### `.gitignore`
 
@@ -1022,32 +1038,6 @@ Even though the `op://`-style `.env` is safe to commit, gitignore any *resolved*
 ```
 
 If you prefer the older convention of keeping `.env` itself gitignored, commit `.env.template` (with `op://` references) instead and have teammates `cp .env.template .env` on first checkout.
-
-#### Long-running servers, CI, and other headless environments
-
-`op run` with desktop-app integration is great for developer laptops, but it can't work where there's no human to unlock the app — GitHub Actions runners, GitLab CI, a VM hosting your Gemini/Claude-backed web app, a cron job, etc. For those, use a [**1Password service account**](https://developer.1password.com/docs/service-accounts/get-started/).
-
-A service account is a non-human identity. You create it in 1Password, scope it to a specific vault (read-only is typical for app deployments), and get back a token like `ops_eyJhbG...`. The server exports that token as `OP_SERVICE_ACCOUNT_TOKEN` and can now run `op run` non-interactively:
-
-```bash
-export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
-op run --env-file=.env -- python app.py
-```
-
-**Is the desktop-login requirement a dealbreaker for a server app? No** — as long as you use a service account, the server itself never needs a logged-in user. **Service account tokens don't expire on their own**; they're valid until you rotate or revoke them in the 1Password admin console. Plan to rotate periodically and immediately if the server is compromised.
-
-::: {.callout-warning}
-## The service account token is itself a secret — don't put it in `.env`
-You can't bootstrap 1Password using 1Password. The `OP_SERVICE_ACCOUNT_TOKEN` has to come from somewhere on the server. Reasonable options:
-
-- **A cloud provider's secret manager** — [GCP Secret Manager](https://cloud.google.com/secret-manager), [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/), or AWS SSM Parameter Store. The token is fetched at startup using the VM's IAM identity (no static credentials on disk).
-- **A systemd `EnvironmentFile`** with `0600` permissions, owned by the service user. Less elegant but works fine for a single VM.
-- **The CI platform's secret store** — GitHub Actions secrets, GitLab CI variables, etc. — for build/deploy pipelines.
-
-If you're already running on GCP or AWS, ask yourself whether 1Password is buying you anything that the cloud's native secret manager isn't. For UW-Madison researchers on institutional GCP/AWS projects, a common pattern is: **1Password for developer machines + the cloud secret manager for production servers.** Use whichever fits the surface.
-:::
-
-See the [CI/CD integrations docs](https://developer.1password.com/docs/ci-cd/) for GitHub Actions, GitLab, and other platforms.
 
 #### Common pitfalls
 

--- a/Learn/Guides/claude-code-cloud-setup.qmd
+++ b/Learn/Guides/claude-code-cloud-setup.qmd
@@ -923,6 +923,22 @@ op run --env-file=.env -- claude     # Claude Code sees the keys; the disk does 
 
 The reference syntax is `op://<vault>/<item>/[section/]<field>` — see the [official reference](https://developer.1password.com/docs/cli/secret-reference-syntax/). The easiest way to get one: right-click a field in the 1Password desktop app and choose **Copy Secret Reference**.
 
+::: {.callout-tip}
+## How `op run` actually works (step by step)
+
+This trips a lot of people up the first time, so it's worth being explicit:
+
+1. **The `.env` file exists on disk**, but it only contains `op://...` references — no real secret values. This file is safe to commit.
+2. **You run `op run --env-file=.env -- python train.py`.** `op run` parses `.env`, sees the references, and fetches the real values from your 1Password vault into memory.
+3. **`op run` spawns `python train.py` as a child process** with `OPENAI_API_KEY=sk-...real-value...` set in *that process's environment only*.
+4. **Your Python script reads `os.environ["OPENAI_API_KEY"]`** and gets the real key — no code changes needed.
+5. **When the Python process exits**, those env vars disappear. Nothing was ever written to `.env`, no temp files, no shell history.
+
+So the real secret only ever lives in the child process's memory. The `.env` on disk only ever holds the pointer. `op run` does **not** rewrite `.env` — there's no "fill in the values at runtime" step that touches the file.
+
+There is a separate command, [`op inject`](https://developer.1password.com/docs/cli/reference/commands/inject/), that *does* write resolved values to a file — useful for tools that can't be wrapped in `op run` (e.g., a daemon's config file). But that output lands on disk, so you gitignore it and delete it afterward. **Default to `op run`** unless you have a specific reason to materialize the file.
+:::
+
 #### Set it up
 
 **Step 1 — Install the 1Password CLI** ([official install docs](https://developer.1password.com/docs/cli/get-started/)):
@@ -964,6 +980,16 @@ HF_TOKEN=op://Private/HuggingFace/token
 
 **Step 5 — Run commands through `op run`.** Your script reads `os.environ["OPENAI_API_KEY"]` (Python) or `process.env.OPENAI_API_KEY` (Node) exactly as before — `op run` populates them transparently.
 
+#### Do I need to be logged into 1Password? How often does it expire?
+
+**For interactive use on your own machine: yes, the 1Password desktop app must be unlocked when you run `op run`.** Day-to-day, this is barely noticeable — the app auto-locks after a period of inactivity (default 10 minutes after sleep, configurable in **Settings → Security**), and unlocking it is a Touch ID / Windows Hello tap. If you run `op run` while the app is locked, it prompts you to unlock right then. No long-lived session tokens land on disk.
+
+If you don't use the desktop-app integration and authenticate via `op signin` instead, **session tokens default to 30 minutes** of inactivity before they expire and you have to re-authenticate. See [Sign in and out](https://developer.1password.com/docs/cli/sign-in-manually/).
+
+**For a long-running server (e.g., a Gemini- or Claude-backed web app serving external users): you do *not* want to rely on a user being logged into 1Password on the server.** That would mean the server can't restart without a human at a keyboard — clearly a dealbreaker for anything production-shaped.
+
+The supported pattern for servers is a [**service account**](https://developer.1password.com/docs/service-accounts/get-started/) (covered below) — a non-human identity with its own long-lived token that the server uses to fetch secrets at startup. No desktop app, no biometrics, no user login required on the server.
+
 #### `.gitignore`
 
 Even though the `op://`-style `.env` is safe to commit, gitignore any *resolved* output from `op inject` (a sibling command that writes the resolved file to disk for tools that can't be wrapped in `op run`):
@@ -977,14 +1003,29 @@ Even though the `op://`-style `.env` is safe to commit, gitignore any *resolved*
 
 If you prefer the older convention of keeping `.env` itself gitignored, commit `.env.template` (with `op://` references) instead and have teammates `cp .env.template .env` on first checkout.
 
-#### Headless / CI use
+#### Long-running servers, CI, and other headless environments
 
-`op run` requires an unlocked 1Password app, which won't work in GitHub Actions, GitLab CI, or other unattended environments. For those, create a [**service account**](https://developer.1password.com/docs/service-accounts/get-started/) scoped to a single vault and export its token as a CI secret:
+`op run` with desktop-app integration is great for developer laptops, but it can't work where there's no human to unlock the app — GitHub Actions runners, GitLab CI, a VM hosting your Gemini/Claude-backed web app, a cron job, etc. For those, use a [**1Password service account**](https://developer.1password.com/docs/service-accounts/get-started/).
+
+A service account is a non-human identity. You create it in 1Password, scope it to a specific vault (read-only is typical for app deployments), and get back a token like `ops_eyJhbG...`. The server exports that token as `OP_SERVICE_ACCOUNT_TOKEN` and can now run `op run` non-interactively:
 
 ```bash
 export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
-op run --env-file=.env -- ./deploy.sh
+op run --env-file=.env -- python app.py
 ```
+
+**Is the desktop-login requirement a dealbreaker for a server app? No** — as long as you use a service account, the server itself never needs a logged-in user. **Service account tokens don't expire on their own**; they're valid until you rotate or revoke them in the 1Password admin console. Plan to rotate periodically and immediately if the server is compromised.
+
+::: {.callout-warning}
+## The service account token is itself a secret — don't put it in `.env`
+You can't bootstrap 1Password using 1Password. The `OP_SERVICE_ACCOUNT_TOKEN` has to come from somewhere on the server. Reasonable options:
+
+- **A cloud provider's secret manager** — [GCP Secret Manager](https://cloud.google.com/secret-manager), [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/), or AWS SSM Parameter Store. The token is fetched at startup using the VM's IAM identity (no static credentials on disk).
+- **A systemd `EnvironmentFile`** with `0600` permissions, owned by the service user. Less elegant but works fine for a single VM.
+- **The CI platform's secret store** — GitHub Actions secrets, GitLab CI variables, etc. — for build/deploy pipelines.
+
+If you're already running on GCP or AWS, ask yourself whether 1Password is buying you anything that the cloud's native secret manager isn't. For UW-Madison researchers on institutional GCP/AWS projects, a common pattern is: **1Password for developer machines + the cloud secret manager for production servers.** Use whichever fits the surface.
+:::
 
 See the [CI/CD integrations docs](https://developer.1password.com/docs/ci-cd/) for GitHub Actions, GitLab, and other platforms.
 

--- a/Learn/Guides/claude-code-cloud-setup.qmd
+++ b/Learn/Guides/claude-code-cloud-setup.qmd
@@ -888,6 +888,118 @@ The `//` prefix in permission rules means "absolute path from the filesystem roo
 **Important caveat:** `Read` deny rules apply on a "best-effort" basis to built-in tools like Grep and Glob. However, if a Bash command (like `cat .env`) is allowed, it can still read the file. This is why denying both `Read` and the relevant `Bash` commands together gives stronger protection. See [this security deep-dive](https://www.petefreitag.com/blog/claude-code-permissions/) for details.
 :::
 
+### Keep secrets out of `.env` files — inject them at runtime with 1Password {#1password-secrets}
+
+Deny rules ([above](#add-deny-rules)) stop Claude Code from reading `.env`, but they don't help if you accidentally `git add .` and commit the file, paste it into a chat, or share your screen. The safer pattern is to **not have an `.env` file on disk in the first place**. Instead, store API keys (Anthropic, OpenAI, HuggingFace, database passwords, etc.) in 1Password and have them injected into the process environment only at the moment a command runs.
+
+::: {.callout-tip}
+## UW-Madison provides free 1Password accounts
+Enrolled students, student employees, and paid faculty/staff are eligible for a **UW-Madison University 1Password account** at no cost. Anyone with a `@wisc.edu` address (including retirees and emeritus) can get a free **Families account**.
+
+- [**UW-Madison 1Password service page**](https://it.wisc.edu/services/1password/) — overview and links
+- [**Eligibility**](https://kb.wisc.edu/security/page.php?id=147122) — who can get which plan
+- [**Request activation**](https://kb.wisc.edu/security/147715) — go to [profile.wisc.edu/doit-services](https://profile.wisc.edu/doit-services), click *Request Activation*, then accept the invite from `accounts@1password.com` and sign in with your NetID at [uw-madison.1password.com](https://uw-madison.1password.com)
+- [**Getting started with 1Password at UW**](https://kb.wisc.edu/security/144301)
+
+UW Health note: do **not** store UW Health or Meriter credentials in 1Password.
+:::
+
+#### How it works
+
+Instead of plaintext like `OPENAI_API_KEY=sk-...` in `.env`, you store a **secret reference** that points to your vault:
+
+```text
+OPENAI_API_KEY=op://Private/OpenAI/api-key
+ANTHROPIC_API_KEY=op://Private/Anthropic/credential
+```
+
+Then you launch your command through [`op run`](https://developer.1password.com/docs/cli/secrets-environment-variables/), which resolves the references and exposes the real values **only inside the child process's environment** — nothing is ever written to disk:
+
+```bash
+op run --env-file=.env -- python train.py
+op run --env-file=.env -- node index.js
+op run --env-file=.env -- claude     # Claude Code sees the keys; the disk does not
+```
+
+The reference syntax is `op://<vault>/<item>/[section/]<field>` — see the [official reference](https://developer.1password.com/docs/cli/secret-reference-syntax/). The easiest way to get one: right-click a field in the 1Password desktop app and choose **Copy Secret Reference**.
+
+#### Set it up
+
+**Step 1 — Install the 1Password CLI** ([official install docs](https://developer.1password.com/docs/cli/get-started/)):
+
+::: {.panel-tabset}
+
+##### macOS
+
+```bash
+brew install 1password-cli
+op --version
+```
+
+##### Windows (PowerShell)
+
+```powershell
+winget install 1Password.CLI
+op --version
+```
+
+##### Linux / WSL2
+
+Follow the apt/dnf instructions on the [official install page](https://developer.1password.com/docs/cli/get-started/). Homebrew on Linux also works.
+
+:::
+
+**Step 2 — Enable desktop app integration.** Open the 1Password 8 desktop app → **Settings → Developer** → enable **"Integrate with 1Password CLI"**. Now `op` authenticates via Touch ID / Windows Hello / system biometrics instead of long-lived session tokens. See the [app integration docs](https://developer.1password.com/docs/cli/app-integration/) and [biometric unlock docs](https://developer.1password.com/docs/cli/use-biometric-unlock/).
+
+**Step 3 — Store your API keys in 1Password.** Create a new item (type: *API Credential* or *Password*) in your UW-Madison vault for each key you use (Anthropic, OpenAI, HuggingFace, etc.).
+
+**Step 4 — Replace your `.env` with references.** The new file contains only `op://...` references — no plaintext secrets — and is **safe to commit** to the repo so the rest of your team knows which variables to set:
+
+```text
+# .env — safe to commit; values resolved at runtime by `op run`
+OPENAI_API_KEY=op://Private/OpenAI/api-key
+ANTHROPIC_API_KEY=op://Private/Anthropic/credential
+HF_TOKEN=op://Private/HuggingFace/token
+```
+
+**Step 5 — Run commands through `op run`.** Your script reads `os.environ["OPENAI_API_KEY"]` (Python) or `process.env.OPENAI_API_KEY` (Node) exactly as before — `op run` populates them transparently.
+
+#### `.gitignore`
+
+Even though the `op://`-style `.env` is safe to commit, gitignore any *resolved* output from `op inject` (a sibling command that writes the resolved file to disk for tools that can't be wrapped in `op run`):
+
+```gitignore
+# Resolved secret files — never commit
+.env.local
+.env.resolved
+*.resolved.env
+```
+
+If you prefer the older convention of keeping `.env` itself gitignored, commit `.env.template` (with `op://` references) instead and have teammates `cp .env.template .env` on first checkout.
+
+#### Headless / CI use
+
+`op run` requires an unlocked 1Password app, which won't work in GitHub Actions, GitLab CI, or other unattended environments. For those, create a [**service account**](https://developer.1password.com/docs/service-accounts/get-started/) scoped to a single vault and export its token as a CI secret:
+
+```bash
+export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+op run --env-file=.env -- ./deploy.sh
+```
+
+See the [CI/CD integrations docs](https://developer.1password.com/docs/ci-cd/) for GitHub Actions, GitLab, and other platforms.
+
+#### Common pitfalls
+
+- **Shell expansion happens before `op run` injects.** `op run -- echo $OPENAI_API_KEY` expands `$OPENAI_API_KEY` in your *parent* shell (where it's empty) before the child runs. Use single quotes and a subshell: `op run -- bash -c 'echo $OPENAI_API_KEY'` — though, ideally, never echo a secret at all.
+- **Don't `export` secrets in your shell profile.** Adding `export OPENAI_API_KEY=...` to `~/.zshrc` puts the plaintext back on disk and defeats the point. Always launch the consuming process under `op run`.
+- **Watch which vault you're signed into.** If you have both a UW-Madison University account and a personal account, `op://Private/...` resolves against whichever account is active. Use `op signin` to switch, or qualify references with the account shorthand.
+- **Shell history.** Once a secret is in the child process's environment, anything that prints it (e.g., `env`, `printenv`, an accidental `echo`) may end up in `~/.bash_history` or `~/.zsh_history`. Treat env-var secrets as memory-only.
+
+::: {.callout-note}
+## This is complementary to deny rules, not a replacement
+Even with 1Password, keep your `.env` deny rules in place — there will be projects (legacy code, third-party tools) where a real `.env` still lands on disk temporarily, and you want Claude blocked from reading it if so. **Defense in depth**: deny rules block reads of any secrets file that *does* exist; 1Password ensures most of them never exist in the first place.
+:::
+
 ### Add `allow` rules to reduce prompt fatigue {#allow-rules}
 
 These also go in **`~/.claude/settings.json`**, inside the same `permissions` block as your deny rules. By default, Claude Code asks "Do you want to proceed?" before *every* file write, shell command, and git operation. This gets old fast — in a typical session you might approve the same `git add`, `git commit`, and `git push` sequence a dozen times. You can add `allow` rules so Claude runs trusted commands without asking:

--- a/Learn/Guides/claude-code-cloud-setup.qmd
+++ b/Learn/Guides/claude-code-cloud-setup.qmd
@@ -1026,6 +1026,18 @@ op run --env-file=.env -- python app.py
 
 Service-account tokens don't expire on their own — they're valid until you rotate or revoke them. Treat the token like any other production credential: don't commit it, and load it through whatever mechanism your platform already uses for sensitive env vars (CI secret stores, your hosting platform's secret UI, systemd `EnvironmentFile`, etc.). See the [CI/CD integrations docs](https://developer.1password.com/docs/ci-cd/) for GitHub Actions, GitLab, Kubernetes, and other recipes.
 
+::: {.callout-note collapse="true"}
+## "Isn't this just kicking the can down the road? You still have to store *something*."
+
+Fair question. The honest answer depends on where you're running.
+
+**On your laptop: there is no long-lived token on disk.** You authenticate to 1Password with three things: a master password (in your head), a Secret Key (random, can be kept offline), and device biometrics (Touch ID / Windows Hello, which live in the OS secure enclave — not a file). The unlocked session sits in the desktop app's memory and expires on lock. None of these are a file an attacker can `cat` off your disk. That's a real improvement over a plaintext `.env` sitting at `~/projects/myapp/.env`.
+
+**On a server: yes, there's a service-account token on disk somewhere — but it's a meaningful reduction.** You've gone from *N* API keys spread across every `.env` file on every server to *one* narrowly-scoped bootstrap credential. That one token can be (a) scoped read-only to a single vault, so the blast radius is bounded if it's grabbed, (b) rotated and revoked centrally in the 1Password admin console instead of SSH-ing into every server, and (c) audited — 1Password logs which service account read which secret when, which raw `.env` files don't. And the actual app secrets (Gemini, DB, etc.) still never touch disk — only the bootstrap token does.
+
+So: laptop case is a clean win. Server case is "one narrowly-scoped, rotatable, audited token instead of many sprawling plaintext credentials." Not zero risk, but defense in depth — not security theater.
+:::
+
 #### `.gitignore`
 
 Even though the `op://`-style `.env` is safe to commit, gitignore any *resolved* output from `op inject` (a sibling command that writes the resolved file to disk for tools that can't be wrapped in `op run`):


### PR DESCRIPTION
## Summary

Added a comprehensive guide section on using 1Password to inject API keys and secrets at runtime instead of storing them in `.env` files. This provides a more secure pattern for managing credentials in Claude Code projects, especially for UW-Madison users who have free access to 1Password.

## Key Changes

- **New section: "Keep secrets out of `.env` files — inject them at runtime with 1Password"** covering:
  - Overview of the safer pattern: storing references (`op://...`) instead of plaintext secrets
  - UW-Madison 1Password eligibility and activation instructions
  - Detailed explanation of how `op run` works (step-by-step walkthrough to clarify common misconceptions)
  - Comparison of `op run` vs. 1Password SDKs with use-case guidance
  - Setup instructions for macOS, Windows, and Linux/WSL2
  - Authentication and session lifetime details for interactive and unattended scenarios
  - `.gitignore` recommendations for resolved secret files
  - Common pitfalls and troubleshooting tips
  - Note on complementary relationship with deny rules

- Positioned the new section before the existing "Add `allow` rules" section to establish secure secret handling as a foundational practice

## Notable Details

- Includes platform-specific CLI installation instructions (macOS/Homebrew, Windows/winget, Linux/apt/dnf)
- Explains the distinction between interactive (biometric-authenticated) and unattended (service-account token) authentication
- Addresses common misconceptions about `op run` not rewriting `.env` files
- Provides context on UW-Madison's free 1Password offering and eligibility criteria
- Emphasizes that this approach is complementary to, not a replacement for, deny rules

https://claude.ai/code/session_01B8AKojGnPXh7d4yuXQ2Eym