### PR TITLE
Add Kaggle challenge link to MaveDB ML-Marathon project

### DIFF
--- a/Projects/ML-Marathon/MaveDB-Variant-Effect.qmd
+++ b/Projects/ML-Marathon/MaveDB-Variant-Effect.qmd
@@ -26,6 +26,7 @@ The MaveDB challenge was featured in the [2025 Machine Learning Marathon (MLM25)
 - **Methods**: Protein language models (e.g., ESM), fine-tuning strategies, and variant effect predictors.
 
 ### Links
+- **Kaggle challenge**: [MaveDB: Amino Acid Substitution Prediction](https://www.kaggle.com/competitions/mave-db-amino-acid-substitution-prediction)
 - **MaveDB**: [mavedb.org](https://www.mavedb.org/)
 - **ML Marathon**: [ml-marathon.wisc.edu](https://ml-marathon.wisc.edu/)
 


### PR DESCRIPTION
MaveDB was the only ML-Marathon project page missing a Kaggle challenge link; added it to match the other project pages.


Claude-Session: https://claude.ai/code/session_01JfgBuddMFnAT1BTJpbnT8L