### PR TITLE
Add Qwen model family page

### DIFF
--- a/Toolbox/Models/Qwen.qmd
+++ b/Toolbox/Models/Qwen.qmd
@@ -1,0 +1,66 @@
+---
+title: "Qwen: Open-Weight Foundation Models"
+date: 2026-08-10
+date-format: long
+image: "../../../images/hugging-face.png"
+
+categories:
+  - Models
+  - Deep learning
+  - NLP
+  - Multimodal
+  - Language modeling
+  - Transformer
+---
+
+Qwen is a family of open-weight foundation models developed by Alibaba Cloud. The family includes language, vision-language, coding, mathematical reasoning, audio, and embedding models that can be used through [Hugging Face](https://huggingface.co/Qwen), [ModelScope](https://modelscope.cn/organization/qwen), and common local inference frameworks. Qwen models are released in a range of sizes, making the family useful for experimentation on local hardware as well as larger-scale deployment.
+
+#### Key features
+
+- **Decoder-only transformer models**: Qwen language models use a transformer architecture for text generation, instruction following, and tool use.
+- **Broad model family**: Specialized Qwen releases support visual question answering, code generation, mathematical reasoning, speech and audio understanding, embeddings, and reranking.
+- **Open weights**: Many Qwen checkpoints are available under permissive licenses, enabling local inference, fine-tuning, and evaluation.
+- **Multilingual support**: Qwen models are trained to work across many languages, with particularly strong support for Chinese and English.
+
+## Timeline context
+
+Qwen is part of the recent wave of openly available large language model families that make foundation-model research and deployment more accessible.
+
+- **[Transformer (2017)](https://arxiv.org/abs/1706.03762)**: Introduced the attention-based architecture used by modern language models.
+- **[BERT (2018)](https://arxiv.org/abs/1810.04805)**: Established large-scale language-model pretraining as a general-purpose NLP approach.
+- **[Llama (2023)](https://arxiv.org/abs/2302.13971)**: Popularized a family of openly released large language models for research and downstream adaptation.
+- **[Qwen (2023)](https://arxiv.org/abs/2309.16609)**: Introduced the original Qwen language-model family and its multilingual, long-context capabilities.
+- **[Qwen2 (2024)](https://arxiv.org/abs/2407.10671)**: Expanded the family with models for language, vision-language, audio, and multilingual applications.
+- **[Qwen3 (2025)](https://arxiv.org/abs/2505.09388)**: Added hybrid reasoning modes and a new generation of dense and mixture-of-experts models.
+
+## Qwen variants
+
+- **[Qwen3](https://huggingface.co/collections/Qwen/qwen3)**: General-purpose language models with configurable thinking and non-thinking modes, available in dense and mixture-of-experts sizes.
+- **[Qwen2.5-VL](https://huggingface.co/collections/Qwen/qwen25-vl)**: Vision-language models for understanding images, documents, charts, and video.
+- **[Qwen2.5-Coder](https://huggingface.co/collections/Qwen/qwen25-coder)**: Code-focused models for generation, completion, debugging, and repository-level software tasks.
+- **[Qwen2.5-Math](https://huggingface.co/collections/Qwen/qwen25-math)**: Models optimized for mathematical problem solving and reasoning.
+- **[Qwen2-Audio](https://huggingface.co/collections/Qwen/qwen2-audio)**: Audio-language models that accept speech and other audio inputs.
+- **[Qwen3 Embedding and Reranker](https://huggingface.co/collections/Qwen/qwen3-embedding)**: Retrieval models for semantic search and retrieval-augmented generation systems.
+
+## Model playground
+
+#### Tutorials and getting started
+
+- **[Qwen documentation](https://qwen.readthedocs.io/en/latest/)**: Official guidance for using Qwen models and their ecosystem.
+- **[Qwen GitHub organization](https://github.com/QwenLM)**: Source code, examples, and model-specific repositories.
+- **[Hugging Face Qwen collection](https://huggingface.co/Qwen)**: Model cards, checkpoints, and usage examples.
+
+#### High-level tips for effective use
+
+- **Match the model to the task**: Select a specialized model such as Qwen2.5-Coder or Qwen2.5-VL when code or visual inputs are central to the workload.
+- **Use chat templates**: Apply the model's documented chat template when prompting instruction-tuned checkpoints to preserve expected roles and control tokens.
+- **Confirm hardware requirements**: Choose a model size and quantization format that fits the available memory; larger models may require multiple GPUs.
+- **Evaluate before deployment**: Test prompts, languages, safety behavior, and latency against the intended use case before relying on a model in production.
+
+## Related resources
+
+- [**Library**: Hugging Face](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Libraries/HuggingFace.html): Tools and model hubs for discovering, downloading, and using Qwen checkpoints.
+- [**Guide**: Generative AI at UW-Madison](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/GenAI/GenAI-at-UW-Madison.html): UW-Madison guidance and resources for generative AI.
+- [**Notebook**: NRP Hosted LLMs](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/NRP-Hosted-LLMs.html): Getting started with hosted language models on NRP.
+
+## Comments


### PR DESCRIPTION
## Summary
- add a Toolbox model page for the Qwen open-weight foundation-model family
- cover text, vision-language, coding, math, audio, embedding, and reranking variants
- link to official documentation and related Nexus resources