### PR TITLE
Add MLM26 challenges: WattBot and Badger Code

### DIFF
--- a/Projects/ML-Marathon/Badger-Code.qmd
+++ b/Projects/ML-Marathon/Badger-Code.qmd
@@ -32,7 +32,6 @@ Badger Code is a challenge in the [2026 Machine Learning Marathon (MLM26)](https
 ## Related resources
 - [**Benchmark**: SWE-bench: Evaluating AI on Real-World Software Engineering](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Benchmarks/SWE-Bench.html): The most widely used benchmark for AI coding agents -- useful background on how agentic coding is evaluated.
 - [**Notebook**: Understanding Quantization and Precision](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/Quantization-and-Precision.html): Learn how quantization (e.g., 4-bit) reduces model size and memory requirements -- essential for fitting capable open models on a single GPU.
-- [**Notebook**: NRP-Hosted LLMs: Access Setup and a First API Call](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/NRP-Hosted-LLMs.html): Access free open-weight LLMs hosted on the National Research Platform -- handy for prototyping your agent before committing to a local setup.
-- [**Compute**: National Research Platform (NRP)](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Compute/NRP-Nautilus.html): Free GPU compute available to UW-Madison researchers and students -- a place to develop and benchmark your agent.
+- [**Compute**: National Research Platform (NRP)](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Compute/NRP-Nautilus.html): Free open-weight LLM endpoints (with a Python code-along) plus free GPU compute for UW-Madison researchers -- prototype your agent against the hosted API, then develop and benchmark on your own GPU pod.
 
 ## Comments

--- a/Projects/ML-Marathon/Badger-Code.qmd
+++ b/Projects/ML-Marathon/Badger-Code.qmd
@@ -1,0 +1,38 @@
+---
+title: "Badger Code: Building an Open Coding Agent on a Single GPU"
+author:
+  - name: Chris Endemann
+    email: endemann@wisc.edu
+
+date: 2026-08-25
+date-format: long
+image: "../../images/claudecode.jpg"
+
+categories:
+  - Projects
+  - ML Marathon
+  - MLM26
+  - Agentic coding
+  - Benchmarking
+  - LLM
+  - GenAI
+
+---
+
+Badger Code is a challenge in the [2026 Machine Learning Marathon (MLM26)](https://ml-marathon.wisc.edu/). Teams build the best open coding agent they can on a single GPU -- no proprietary models, no giant clusters -- scored on Terminal-Bench 2.1. Terminal-Bench measures whether an agent can use shell commands, inspect files, read error messages, and iterate until the task is complete, connecting models to a sandboxed terminal for reproducible evaluation.
+
+### Challenge design
+- **Task**: Assemble an agent (open-weights model + harness) that solves real terminal-based tasks end to end.
+- **Constraints**: Open models only, running on a single GPU -- efficiency and clever harness design matter as much as raw model size.
+- **Evaluation**: Terminal-Bench 2.1 task completion rate in a sandboxed, reproducible execution harness.
+
+### Links
+- **Kaggle challenge**: [Badger Code](https://www.kaggle.com/competitions/OpenAgent-Coding)
+
+## Related resources
+- [**Benchmark**: SWE-bench: Evaluating AI on Real-World Software Engineering](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Benchmarks/SWE-Bench.html): The most widely used benchmark for AI coding agents -- useful background on how agentic coding is evaluated.
+- [**Notebook**: Understanding Quantization and Precision](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/Quantization-and-Precision.html): Learn how quantization (e.g., 4-bit) reduces model size and memory requirements -- essential for fitting capable open models on a single GPU.
+- [**Notebook**: NRP-Hosted LLMs: Access Setup and a First API Call](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/NRP-Hosted-LLMs.html): Access free open-weight LLMs hosted on the National Research Platform -- handy for prototyping your agent before committing to a local setup.
+- [**Compute**: National Research Platform (NRP)](https://uw-madison-datascience.github.io/ML-X-Nexus/Toolbox/Compute/NRP-Nautilus.html): Free GPU compute available to UW-Madison researchers and students -- a place to develop and benchmark your agent.
+
+## Comments

--- a/Projects/ML-Marathon/Badger-Code.qmd
+++ b/Projects/ML-Marathon/Badger-Code.qmd
@@ -6,7 +6,7 @@ author:
 
 date: 2026-08-25
 date-format: long
-image: "../../images/claudecode.jpg"
+image: "../../images/BadgerCode.jpg"
 
 categories:
   - Projects

--- a/Projects/ML-Marathon/WattBot-2026.qmd
+++ b/Projects/ML-Marathon/WattBot-2026.qmd
@@ -1,0 +1,45 @@
+---
+title: "WattBot 2026: Investigating AI's Environmental Footprint with RAG"
+author:
+  - name: Chris Endemann
+    email: endemann@wisc.edu
+
+date: 2026-08-25
+date-format: long
+image: "../../images/WattBot.png"
+
+categories:
+  - Projects
+  - ML Marathon
+  - MLM26
+  - RAG
+  - Retrieval
+  - LLM
+  - NLP
+  - Sustainability
+  - Energy
+  - GenAI
+
+---
+
+WattBot is back for the [2026 Machine Learning Marathon (MLM26)](https://ml-marathon.wisc.edu/) -- bigger and tougher than last year. Teams build retrieval-augmented generation (RAG) systems that answer over 500 questions about AI's environmental impact from a corpus of over 100 papers and public reports, including arXiv preprints, peer-reviewed work, LBNL/IEA/GAO reporting, corporate sustainability filings, and a regional cluster on Wisconsin and the Great Lakes. Every answer needs a citation and supporting evidence, and when the corpus can't support an answer, the system must say so instead of guessing. The goal: turn scattered evidence into transparent, actionable answers for researchers, engineers, and policymakers.
+
+### Challenge design
+- **Task**: For each question, return a concise answer, a normalized answer value, the supporting document ID(s), verbatim supporting materials, and the reasoning connecting evidence to answer -- or explicitly abstain (`is_blank`) when the corpus can't answer.
+- **Question types**: Range from locating a stated fact, to reading values off figures (OCR and vision models are fair game), combining documents, attributing a company's claim as a claim, and reconciling conflicting sources.
+- **Evaluation**: The WattBot Score -- a weighted accuracy over answer correctness (0.75), citation F1 (0.20), and proper abstention on unanswerable questions (0.05). The exact scorer ships with the data so you can validate locally before submitting.
+- **Bonus track**: Teams are invited to build a chatbot application around their RAG methods -- judged informally on visible citations, speed, grounded accuracy, and completeness.
+
+### Links
+- **Kaggle challenge**: [WattBot 2026](https://www.kaggle.com/competitions/WattBot2026)
+- **Last year's edition**: [WattBot 2025](https://uw-madison-datascience.github.io/ML-X-Nexus/Projects/ML-Marathon/WattBot-2025.html)
+
+## Related resources
+- [**Project**: WattBot 2025: Estimating AI Emissions with RAG](https://uw-madison-datascience.github.io/ML-X-Nexus/Projects/ML-Marathon/WattBot-2025.html): The first WattBot challenge, including the winning RAG solution and deployment repos -- a natural starting point for 2026 teams.
+- [**Talk**: Deploying RAG in Bedrock vs. Local: WattBot 2025 Case Study](https://uw-madison-datascience.github.io/ML-X-Nexus/Applications/Videos/Forums/mlx_2026-02-17.html): ML+X forum where the winning WattBot 2025 RAG system was deployed in AWS Bedrock and locally with open-source models.
+- [**Talk**: AI's Environmental Footprint: Insights and Actions](https://uw-madison-datascience.github.io/ML-X-Nexus/Applications/Videos/Forums/mlx_2025-09-09.html): The ML+X forum where WattBot was first introduced alongside LLM energy benchmarking work.
+- [**Notebook**: Exploring Fact-Based QA with RAG: Romeo and Juliet](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/2025-05-07_RAG-Romeo-Juliet.html): Build an end-to-end RAG pipeline from scratch -- a great starting point before tackling WattBot.
+- [**Workshop**: Intro to AWS SageMaker for Predictive ML/AI](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Workshops/Intro-Amazon_SageMaker.html): Covers AWS SageMaker and Bedrock for cloud-based ML/AI workflows, including RAG deployment.
+- [**Notebook**: Understanding Quantization and Precision](https://uw-madison-datascience.github.io/ML-X-Nexus/Learn/Notebooks/Quantization-and-Precision.html): Learn how quantization (e.g., 4-bit) reduces model size and memory requirements -- useful for running open models locally in your pipeline.
+
+## Comments

--- a/Projects/ML-Marathon/index.qmd
+++ b/Projects/ML-Marathon/index.qmd
@@ -22,8 +22,8 @@ comments: false
 ---
 The [Machine Learning Marathon (MLM)](https://ml-marathon.wisc.edu/) is an annual 12-week ML/AI hackathon hosted by the [ML+X](https://datascience.wisc.edu/ml-community/) community at UW-Madison. Each fall, teams of 2-5 tackle real-world challenges sourced from UW researchers, industry partners, and the broader Kaggle community. Challenges span a range of domains and difficulty levels -- from beginner-friendly to competitive challenges with prizes.
 
-Most challenges remain open on Kaggle after the Marathon ends, making them great self-study material any time of year. Dive into the datasets, explore the discussion tabs for tips and solution writeups from past participants, and benchmark your own approaches at your own pace.
+Below you'll find challenges from the current Marathon alongside editions from past years -- use the category filters (e.g., MLM26, MLM25) to browse by season. Most challenges remain open on Kaggle even after their Marathon season ends, making them great self-study material any time of year. Dive into the datasets, explore the discussion tabs for tips and solution writeups from past participants, and benchmark your own approaches at your own pace.
 
 Want to participate live? [Join ML+X](https://datascience.wisc.edu/ml-community/) and watch for the next Marathon registration each September. Interested in proposing a challenge? Visit [ml-marathon.wisc.edu](https://ml-marathon.wisc.edu/) or reach out to [Chris Endemann](mailto:endemann@wisc.edu).
 
-### Explore past challenges
+### Explore challenges, past and present

--- a/Projects/ML-Marathon/index.qmd
+++ b/Projects/ML-Marathon/index.qmd
@@ -24,6 +24,6 @@ The [Machine Learning Marathon (MLM)](https://ml-marathon.wisc.edu/) is an annua
 
 Below you'll find challenges from the current Marathon alongside editions from past years -- use the category filters (e.g., MLM26, MLM25) to browse by season. Most challenges remain open on Kaggle even after their Marathon season ends, making them great self-study material any time of year. Dive into the datasets, explore the discussion tabs for tips and solution writeups from past participants, and benchmark your own approaches at your own pace.
 
-Want to participate live? [Join ML+X](https://datascience.wisc.edu/ml-community/) and watch for the next Marathon registration each September. Interested in proposing a challenge? Visit [ml-marathon.wisc.edu](https://ml-marathon.wisc.edu/) or reach out to [Chris Endemann](mailto:endemann@wisc.edu).
+Want to participate live? [Join ML+X](https://datascience.wisc.edu/ml-community/) and watch for the next Marathon registration each September. Interested in proposing a challenge? Reach out to [Chris Endemann](mailto:endemann@wisc.edu).
 
 ### Explore challenges, past and present

--- a/Projects/index.qmd
+++ b/Projects/index.qmd
@@ -21,6 +21,6 @@ toc-location: body
 page-layout: full
 title-block-banner: false
 ---
-Explore past and ongoing ML/AI projects from the UW-Madison community. From the annual [Machine Learning Marathon](https://ml-marathon.wisc.edu/) to campus lab collaborations, these projects showcase real-world applications, lessons learned, and community insights.
+Explore hands-on ML/AI projects from the UW-Madison community, past and present. From the annual [Machine Learning Marathon](https://ml-marathon.wisc.edu/) -- including the currently running challenges -- to campus lab collaborations, these projects showcase real-world applications, lessons learned, and community insights.
 
 Projects and Nexus go hand in hand. Nexus resources -- workshops, guides, models, and datasets -- help practitioners hit the ground running on new challenges. In turn, projects surface blind spots, new tools, and hard-won lessons that get contributed back to Nexus. The result is a virtuous cycle: each project makes the next one easier for everyone.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -51,8 +51,13 @@ website:
       - section: "Projects"
         href: Projects/index.qmd
         contents:
-          - text: "ML Marathon"
+          - section: "ML Marathon"
             href: Projects/ML-Marathon/index.qmd
+            contents:
+              - text: "MLM26"
+                href: Projects/ML-Marathon/index.qmd#category=MLM26
+              - text: "MLM25"
+                href: Projects/ML-Marathon/index.qmd#category=MLM25
 
       - section: "Stories"
         href: Applications/index.qmd


### PR DESCRIPTION
## Summary
Add two new Machine Learning Marathon 2026 (MLM26) challenge pages and update navigation to support browsing challenges by season.

## Key Changes
- **New challenge pages**:
  - `WattBot 2026`: RAG system challenge to answer questions about AI's environmental footprint from a corpus of 100+ papers and reports, with citation requirements and proper abstention handling
  - `Badger Code`: Open coding agent challenge to build efficient agents on a single GPU, evaluated on Terminal-Bench 2.1
  
- **Navigation improvements**:
  - Convert "ML Marathon" navigation item from flat link to expandable section with MLM26 and MLM25 category filters
  - Update `_quarto.yml` to support hierarchical navigation with category-based filtering
  
- **Content updates**:
  - Clarify ML Marathon index page to emphasize both current and past challenges with category filtering
  - Update Projects index to highlight that challenges are part of the current offerings, not just historical projects

## Implementation Details
Both challenge pages follow the existing project template with metadata (author, date, categories), challenge design sections, relevant links, and curated learning resources. The navigation restructuring enables users to filter challenges by season (MLM26, MLM25, etc.) while maintaining backward compatibility with existing links.

https://claude.ai/code/session_011FpvovDyjqZ7anJTdb3qMX